### PR TITLE
Update Hugo build step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         extended: true
 
     - name: Build
-      run: hugo --minify 
+      run: hugo --minify --panicOnWarning
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Summary
- fail CI when Hugo emits warnings

## Testing
- `go test ./...` *(fails: no packages to test)*
- `hugo --minify --panicOnWarning` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d38c0f8b4832881d2ad202de04e8d