### PR TITLE
Fix sed in init_kickstart

### DIFF
--- a/scripts/init_kickstart.sh
+++ b/scripts/init_kickstart.sh
@@ -36,7 +36,8 @@ rsync -av ../themes/academic/exampleSite/content/talk/_index.md ../content/talk/
 # Post processing
 
 # Deactivate Hero
-sed -i '' -e 's/active = true/active = false/' ../content/home/hero.md
+# Use portable in-place editing across GNU/BSD sed
+sed -i.bak -e 's/active = true/active = false/' ../content/home/hero.md && rm -f ../content/home/hero.md.bak
 
 # Manual Steps:
 # - content/home/project.md: Re-comment out project filters


### PR DESCRIPTION
## Summary
- fix non-portable sed command in init_kickstart.sh

## Testing
- `bash -n scripts/init_kickstart.sh`
- `bash -n update_academic.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d1d47bd8c8328995794b6e1b7f65d